### PR TITLE
 Handle target path variable rewrite

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -2,14 +2,9 @@ declare const REDIRECT_KV: KVNamespace; // estlint-disable-line no-undef
 
 export async function handleRequest(request: Request): Promise<Response> {
 	const requestUrl = new URL(request.url);
-	const requestPath = requestUrl.pathname;
-	const requestRootPath = `${requestUrl.host}/`;
 
 	// Get the matching target URL by first checking against the full url then host and then the path
-	const target =
-		(await REDIRECT_KV.get(`${requestUrl.host}${requestUrl.pathname}`)) ??
-		(await REDIRECT_KV.get(requestRootPath)) ??
-		(await REDIRECT_KV.get(requestPath));
+	const target = await getTargetfromKV(requestUrl);
 
 	if (!target || target === '404') {
 		// Optionally redirect to custom page on 404
@@ -44,12 +39,27 @@ export async function handleRequest(request: Request): Promise<Response> {
 
 	// Construct URL class from target (value from KV) so we can easily manipulate it
 	const targetUrl = new URL(target);
+
 	// Default to using targetUrl path
 	let redirectPath = targetUrl.pathname;
+
 	// Check if the request has a path though
-	if (!emptyPath(requestPath) && emptyPath(targetUrl.pathname)) {
+	if (!emptyPath(requestUrl.pathname) && emptyPath(targetUrl.pathname)) {
 		// Since request has a path but target does not, use requestPath
-		redirectPath = requestPath;
+		redirectPath = requestUrl.pathname;
+	}
+
+	// Check if the target has variables to be swapped out
+	if (redirectPath.includes('$')) {
+		try {
+			redirectPath = replaceVariables(redirectPath, requestUrl.pathname);
+		} catch (error: any) {
+			console.error('error', error.message);
+			return new Response('Sorry, page not found.', {
+				status: 404,
+				statusText: 'page not found',
+			});
+		}
 	}
 
 	// Construct a redirect url using target host and redirect path
@@ -68,4 +78,58 @@ export async function handleRequest(request: Request): Promise<Response> {
 
 function emptyPath(path: string): boolean {
 	return path === '/';
+}
+
+function replaceVariables(targetPath: string, requestPath: string): string {
+	const requestPathParts = requestPath.split('/');
+	const targetPathParts = targetPath.split('/');
+
+	// Loop through the parts to replace variables
+	for (let i = 0; i < targetPathParts.length; i++) {
+		if (targetPathParts[i].includes('$')) {
+			// Replace the variable with the actual value
+			const index = parseInt(targetPathParts[i].replace('$', ''), 10);
+			if (requestPathParts[index] !== undefined) {
+				targetPathParts[i] = requestPathParts[index];
+			} else {
+				throw new Error(
+					`Variable ${targetPathParts[i]} not found in request path`,
+				);
+			}
+		}
+	}
+
+	// Join the parts back together
+	return targetPathParts.join('/');
+}
+
+async function getTargetfromKV(requestUrl: URL): Promise<string> {
+	const requestPath = requestUrl.pathname;
+	const requestRootPath = `${requestUrl.host}/`;
+
+	const splittedPath = requestPath.split('/');
+
+	// construct an array of path
+	const requestPaths = [`${requestUrl.host}${splittedPath[0]}`];
+	for (let index = 1; index < splittedPath.length; index++) {
+		requestPaths.push(`${requestPaths[index - 1]}/${splittedPath[index]}`);
+	}
+
+	// reverse the array so we can check from the most specific path
+	requestPaths.reverse();
+
+	// add the root paths to the array
+	requestPaths.push(requestRootPath);
+	requestPaths.push(requestPath);
+
+	// test the route from the most specific path to the root path
+	for (const path of requestPaths) {
+		const target = await REDIRECT_KV.get(path);
+		if (target) {
+			// return then first target found (most specific)
+			return target;
+		}
+	}
+
+	return '404';
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -66,10 +66,15 @@ export async function handleRequest(request: Request): Promise<Response> {
 	const redirectUrl = new URL(
 		`${targetUrl.protocol}//${targetUrl.host}${redirectPath}`,
 	);
-	Array.from(requestUrl.searchParams).forEach(([key, val]) => {
+	// Add the search params from the target to the redirect URL
+	Array.from(targetUrl.searchParams).forEach(([key, val]) => {
 		if (redirectUrl.searchParams.has(key) === false) {
 			redirectUrl.searchParams.set(key, val);
 		}
+	});
+	// Override the search params with the ones from the request
+	Array.from(requestUrl.searchParams).forEach(([key, val]) => {
+		redirectUrl.searchParams.set(key, val);
 	});
 
 	// Redirect to the target URL

--- a/test/handler.ts
+++ b/test/handler.ts
@@ -7,33 +7,36 @@ const routeTest = {
   "https://sourcetopathtrailing.com/": "https://destination.com/path/",
   "https://source.com/path": "https://destination.com/path",
   "https://source.com/pathtrailing/": "https://destination.com/pathtrailing/",
-}
+  "https://notrailing.com": "https://destination.com/",
+  "https://replace.com/replace/hello/world":
+    "https://destination.com/replace/world/hello",
+};
 
 const test404 = [
-  "https://missingtrailing.com",
   "https://noredirect.com",
-]
+  "https://replace.com/replace/notenough",
+];
 
 describe("handler returns target when asked for source", () => {
-  for(let source in routeTest) {
+  for (let source in routeTest) {
     if (Object.prototype.hasOwnProperty.call(routeTest, source)) {
       const destination = routeTest[source];
       it(`route from ${source} to ${destination}`, async () => {
         const request = new Request(`${source}`, { method: "GET" });
         const result = await handleRequest(request);
-        expect (result.status).to.equal(301);
-        expect (result.headers.get("location")).to.equal(destination);
+        expect(result.status).to.equal(301);
+        expect(result.headers.get("location")).to.equal(destination);
       });
     }
   }
 });
 
 describe("handler returns 404 for malformed or unknown source", () => {
-  test404.forEach(source => {
+  test404.forEach((source) => {
     it(`404 from ${source}`, async () => {
       const request = new Request(`${source}`, { method: "GET" });
       const result = await handleRequest(request);
-      expect (result.status).to.equal(404);
+      expect(result.status).to.equal(404);
     });
-  })
+  });
 });

--- a/test/handler.ts
+++ b/test/handler.ts
@@ -10,6 +10,10 @@ const routeTest = {
   "https://notrailing.com": "https://destination.com/",
   "https://replace.com/replace/hello/world":
     "https://destination.com/replace/world/hello",
+  "https://source.com/index?0[0][n]=any&0[0][o]=full_text_search&0[0][v]=rosetta":
+    "https://destination.com/index?0[0][n]=any&0[0][o]=full_text_search&0[0][v]=rosetta",
+  "https://searchparameters.com/":
+    "https://destination.com/index?0[0][n]=any&0[0][o]=full_text_search&0[0][v]=rosetta",
 };
 
 const test404 = [
@@ -21,11 +25,16 @@ describe("handler returns target when asked for source", () => {
   for (let source in routeTest) {
     if (Object.prototype.hasOwnProperty.call(routeTest, source)) {
       const destination = routeTest[source];
+      if (!source.startsWith("http")) {
+        source = `https://${source}`;
+      }
       it(`route from ${source} to ${destination}`, async () => {
         const request = new Request(`${source}`, { method: "GET" });
         const result = await handleRequest(request);
         expect(result.status).to.equal(301);
-        expect(result.headers.get("location")).to.equal(destination);
+        expect(decodeURIComponent(result.headers.get("location"))).to.equal(
+          decodeURIComponent(destination),
+        );
       });
     }
   }

--- a/test/kv.json
+++ b/test/kv.json
@@ -3,5 +3,6 @@
   "notrailing.com": "https://destination.com/",
   "sourcetopath.com": "https://destination.com/path",
   "sourcetopathtrailing.com/": "https://destination.com/path/",
-  "replace.com/replace": "https://destination.com/replace/$3/$2"
+  "replace.com/replace": "https://destination.com/replace/$3/$2",
+  "searchparameters.com/": "https://destination.com/index?0[0][n]=any&0[0][o]=full_text_search&0[0][v]=rosetta"
 }

--- a/test/kv.json
+++ b/test/kv.json
@@ -1,6 +1,7 @@
 {
   "source.com/": "https://destination.com/",
-  "missingtrailing.com": "https://destination.com/",
+  "notrailing.com": "https://destination.com/",
   "sourcetopath.com": "https://destination.com/path",
-  "sourcetopathtrailing.com/": "https://destination.com/path/"
+  "sourcetopathtrailing.com/": "https://destination.com/path/",
+  "replace.com/replace": "https://destination.com/replace/$3/$2"
 }


### PR DESCRIPTION
Allow using $index in the target path to change parameters order in redirects.

Also fixes the redirects when the target url contains searchParameters (they were dropped before); note that they will be overridden by the query search parameters if some are conflicting

See tests/kv.json for an example.

depends-on: https://github.com/balena-io/cf-worker-redirect/pull/5

[Zulip Context](https://balena.zulipchat.com/#narrow/channel/408336-aspect.2Fuser-experience/topic/Feature.20Request.20Migration/near/502241593)